### PR TITLE
Store updates, search refactor

### DIFF
--- a/lib/search-engines.js
+++ b/lib/search-engines.js
@@ -16,6 +16,7 @@ if (!require("api-utils/xul-app").is("Firefox")) {
 const { Trait } = require('traits');
 const { EventEmitter } = require("events");
 const SimpleStorage = require("simple-storage");
+const storage = SimpleStorage.storage;
 const { SearchEnginesCollector } = require("search-engines-collector");
 const data = require("self").data;
 const URL = require("url");
@@ -137,7 +138,7 @@ const SearchEngines = EventEmitter.compose({
 
   get tags() {
     var tags = [];
-    for (var t in this._engines) {
+    for (var t in storage.tags) {
       tags.push(t);
     }
     return tags;
@@ -160,8 +161,9 @@ const SearchEngines = EventEmitter.compose({
   },
 
   constructor : function SearchEngines() {
-    if (!SimpleStorage.storage.engines) {
-      SimpleStorage.storage.engines = {};
+    if (!storage.engines) {
+      storage.engines = {};
+      storage.tags = {};
       this._first_run();
     }
 
@@ -207,70 +209,88 @@ const SearchEngines = EventEmitter.compose({
   },
 
   remove : function remove(engine) {
-    SimpleStorage.storage.engines[engine.id] = null;
-    delete SimpleStorage.storage.engines[engine.id];
+    delete storage.engines[engine.id];
     this._emit("removed", engine);
   },
 
   get : function get(id) {
-    return SimpleStorage.storage.engines[id];
+    return storage.engines[id];
   },
 
   getEnginesByTag : function(tag) {
     tag = (tag)? tag : DEFAULT_TAG;
+
+    if (!this._engines[tag]) {
+      var ids = storage.tags[tag];
+
+      // If no IDs in storage, just create an empty array.
+      if (ids || !ids.length) {
+        this._engines[tag] = [];
+      }
+
+      // Convert engine IDs into the engine objects.
+      this._engines[tag] = ids.map(function(id) {
+        var savedEngine = storage.engines[id];
+        return SearchEngine(savedEngine.siteURL,
+                            savedEngine.name,
+                            savedEngine.queryURL,
+                            savedEngine.suggestionURL,
+                            savedEngine.icon);
+      });
+    }
     return this._engines[tag];
   },
 
   add : function add(engine, tags) {
-    for (var i in tags) {
+    for (var i = 0; i < tags.length; i++) {
       var tag = tags[i];
       this._updateTags(tag, engine);
     }
 
     // Save this engine to the simple storage according to it's provided ID
-    SimpleStorage.storage.engines[engine.id] = engine;
+    storage.engines[engine.id] = engine;
+
     this._emit("added", engine);
   },
 
   _updateTags : function _updateTags(tag, engine) {
-      // If the tag doesn't exist yet just create it
-      if (!this._engines[tag]) {
-        this._engines[tag] = [];
+      // Remove the cached version, will be regenerated on next getEnginesByTag
+      if (this._engines[tag]) {
+        delete this._engines[tag];
       }
 
-      var found = false;
-      for (var e in this._engines[tag]) {
-        if (this._engines[tag][e].id == engine.id) {
-          found = true;
-          this._engines[tag][e] = engine;
-          console.log("added", tag, engine.id)
-          break;
-        }
+      if (!storage.tags[tag]) {
+        storage.tags[tag] = [];
       }
 
-      if (!found) {
-        console.log("pushed", tag, engine.id, this._engines[tag].length);
-        this._engines[tag].push(engine);
+      //Only add it if it does not already exist.
+      var index = storage.tags[tag].indexOf(engine.id);
+      if (index === -1) {
+        console.log("pushed", tag, engine.id);
+        storage.tags[tag].push(engine.id);
       }
   },
 
   // Helper function for adding a tag to an engine and to the cache list of engines
   addTagById : function addTagById(tag, id) {
     console.log("addTagById", tag, id);
-    var engine = SimpleStorage.storage.engines[id];
+    var engine = storage.engines[id];
     this._updateTags(tag, engine);
   },
 
   // Helper function for removing a tag from an engine and from the cache list of engines
   removeTagById : function removeTagById(tag, id) {
     console.log("removeTagById", tag, id);
-    var engine = SimpleStorage.storage.engines[id];
-    for (var e in this._engines[tag]) {
-      if (this._engines[tag][e].id == engine.id) {
-        this._engines[tag][e] = null;
-        delete this._engines[tag][e];
-        break;
-      }
+
+    // Clear the cache, will be regenerated on next call to getEnginesByTag
+    if (this._engines[tag]) {
+      delete this._engines[tag];
+    }
+
+    var index = storage.tags[tag].indexOf(id);
+    if (index !== -1) {
+      console.log("removing id from tag", id, tag);
+      storage.tags[tag].splice(index, 1);
     }
   },
 
@@ -278,85 +298,8 @@ const SearchEngines = EventEmitter.compose({
     this._terms = terms;
     tags = (tags)? tags : [DEFAULT_TAG];
 
-    var run = function() {
-      var engines = this.getEnginesByTag();
-      for (var i in engines) {
-        var engine = engines[i];
-
-        // If our terms are older than the terms set break and quit
-        if (this._terms != terms) {
-          break;
-        }
-
-        // If this engine doesn't support suggestions just skip it
-        if (!engine.suggestionURL) {
-          console.log("engine.suggestionURL", engine.suggestionURL);
-          continue;
-        }
-
-        var request = function(engine, terms) {
-          var req = new xhr.XMLHttpRequest();
-          var url = engine.getSuggestion(terms, Geolocation.formatted_address);
-          req.open('GET', url, true);
-          req.onreadystatechange = function (aEvt) {
-            if (req.readyState == 4) {
-              if (req.status == 200) {
-                console.log("this._terms", this._terms, terms, engine.id);
-
-                // Our request returned but it's too late and the terms have changed
-                if (this._terms != terms) {
-                  return;
-                }
-
-                // ["term", ["suggestions", "of", "matches" ]]
-                // ex: ["json",["jsonline","json","json validator","jsonp"]]
-                try {
-                  if (engine.id == "http://www.yelp.com/search.xml") {
-                    // Yelp returns a crappy HTML answer instead of JSON
-                    // We just send the whole body object to the iframe to let the DOM parse it all
-                    // {"body": "<ul>\n\t\t\t
-                    //            <li title=\"Elysian Coffee\">Elysian<span class=\"highlight\">&nbsp;Coffee</span></li>\n\t\t\t
-                    //            <li title=\"Elysian Room\">Elysian<span class=\"highlight\">&nbsp;Room</span></li>\n\t
-                    //           </ul>",
-                    // "unique_request_id": "a1fdaa421112b2b5"}
-                    var response = JSON.parse(req.responseText)["body"];
-                    this._emit("suggestions", "yelp",{ "terms" : terms, "name" : engine.name, "id" : engine.id,
-                                                       "results" : response, "type" : engine.type });
-                    return;
-                  } else {
-                    var results = [];
-                    var suggestions = JSON.parse(req.responseText)[1];
-                    console.log("req.responseText", req.responseText);
-                    suggestions.forEach(function(item) {
-                      // Break loop if we have more results than we need
-                      if (results.length >= SearchEngines.maxResults) {
-                        return;
-                      }
-                      // If the term searched matches the response then ignore it
-                      if (terms != item) {
-                        results.push({ "title" : item, "url" : (engine.type == "match")? engine.baseURL + item : "" });
-                      }
-                    });
-                    this._emit("suggestions", "add",{ "name" : engine.name, "id" : engine.id,
-                                                      "results" : results, "type" : engine.type, "terms" : terms });
-                  }
-                } catch (error) { console.error("suggest error: " + error + "\n" + url + "\n"); }
-              }
-              else {
-                console.error('req.error', req.readyState, req.status, req.statusText, url);
-              }
-            }
-          }.bind(this);
-          req.send(null);
-
-        }.bind(this);
-
-        request(engine, terms);
-
-      }
-    }.bind(this);
     console.log("this.suggestionTimer", this, this._suggestionTimer);
-    this._suggestionTimer = timers.setTimeout(run, 300);
+    this._suggestionTimer = timers.setTimeout(this._run.bind(this, terms), 300);
     console.log("this.suggestionTimer", this, this._suggestionTimer);
   },
 
@@ -375,9 +318,96 @@ const SearchEngines = EventEmitter.compose({
   // XXX Totally untested
   _overQuota: function _overQuota() {
     //while (SimpleStorage.quotaUsage > 1) {
-    //  SimpleStorage.storage.engines;
+    //  storage.engines;
     //}
     console.error("_overQuota");
+  },
+
+  // Runs the XHR calls to the engines.
+  _run : function (terms) {
+    var engines = this.getEnginesByTag();
+    for (var i = 0; i < engines.length; i++) {
+      var engine = engines[i];
+
+      // If our terms are older than the terms set break and quit
+      if (this._terms != terms) {
+        break;
+      }
+
+      // If this engine doesn't support suggestions just skip it
+      if (!engine.suggestionURL) {
+        console.log("engine.suggestionURL", engine.suggestionURL);
+        continue;
+      }
+
+      // TODO: Could collect the xhrs returned from this call and for instance,
+      // call abort() on them when the terms change.
+      this._query(engine, terms);
+    }
+  },
+
+  _query : function (engine, terms) {
+    var url = engine.getSuggestion(terms, Geolocation.formatted_address);
+    return this._xhr(url, function(req) {
+      console.log("this._terms", this._terms, terms, engine.id);
+
+      // Our request returned but it's too late and the terms have changed
+      if (this._terms != terms) {
+        return;
+      }
+
+      // ["term", ["suggestions", "of", "matches" ]]
+      // ex: ["json",["jsonline","json","json validator","jsonp"]]
+      try {
+        if (engine.id == "http://www.yelp.com/search.xml") {
+          // Yelp returns a crappy HTML answer instead of JSON
+          // We just send the whole body object to the iframe to let the DOM parse it all
+          // {"body": "<ul>\n\t\t\t
+          //            <li title=\"Elysian Coffee\">Elysian<span class=\"highlight\">&nbsp;Coffee</span></li>\n\t\t\t
+          //            <li title=\"Elysian Room\">Elysian<span class=\"highlight\">&nbsp;Room</span></li>\n\t
+          //           </ul>",
+          // "unique_request_id": "a1fdaa421112b2b5"}
+          var response = JSON.parse(req.responseText)["body"];
+          this._emit("suggestions", "yelp",{ "terms" : terms, "name" : engine.name, "id" : engine.id,
+                                             "results" : response, "type" : engine.type });
+          return;
+        } else {
+          var results = [];
+          var suggestions = JSON.parse(req.responseText)[1];
+          console.log("req.responseText", req.responseText);
+          suggestions.forEach(function(item) {
+            // Break loop if we have more results than we need
+            if (results.length >= SearchEngines.maxResults) {
+              return;
+            }
+            // If the term searched matches the response then ignore it
+            if (terms != item) {
+              results.push({ "title" : item, "url" : (engine.type == "match")? engine.baseURL + item : "" });
+            }
+          });
+          this._emit("suggestions", "add",{ "name" : engine.name, "id" : engine.id,
+                                            "results" : results, "type" : engine.type, "terms" : terms });
+        }
+      } catch (error) { console.error("suggest error: " + error + "\n" + url + "\n"); }
+    }.bind(this));
+  },
+
+  // Runs an XHR and calls callback with the XHR request that successfully
+  // completes.
+  _xhr: function (url, callback) {
+      var req = new xhr.XMLHttpRequest();
+      req.open('GET', url, true);
+      req.onreadystatechange = function (aEvt) {
+        if (req.readyState == 4) {
+          if (req.status == 200) {
+            callback(req);
+          } else {
+            console.error('req.error', req.readyState, req.status, req.statusText, url);
+          }
+        }
+      };
+      req.send(null);
+      return req;
   },
 
   unload : function unload() {


### PR DESCRIPTION
## Save and restore engines and tags more completely

Allows reuse of the same profile over multiple runs. Now "engines" and "tags" are stored in SimpleStorage, and this._engines is only generated for a particular tag when getEnginesByTag() is called.
## Refactored search internals to be a few different methods.

Just to split up the size of the search.
