### PR TITLE
Yelp translator and geolocation monitor

### DIFF
--- a/data/results.js
+++ b/data/results.js
@@ -171,31 +171,6 @@ function go() {
   $(".result.selected").click();
 }
 
-// This hack makes the Yelp HTML results work with real suggestion results
-self.port.on("yelp", function(results) {
-
-  // Use the DOM to parse and extract the title information (suggestions)
-  var terms = [], count = 3;
-  $("<div/>").html(results.results).find("li[title]").each(function () {
-    if (count-- <= 0) {
-      return;
-    }
-    var item = $(this).attr("title");
-
-    // Skip the suggestion that is a copy of our user entered terms
-    if (results.terms != item) {
-      terms.push({ "title" : item, "url" : ""});
-    }
-  });
-
-  results.results = terms;
-
-  // Send the new results to our add() method for inserting
-  add(results);
-
-});
-
-
 // Highlight the text with the terms provided while preserving the case used
 // returns <strong>wrappers</strong> around the terms found in the text
 function highlight(text, terms) {

--- a/lib/geolocation.js
+++ b/lib/geolocation.js
@@ -120,6 +120,7 @@ const Geolocation = EventEmitter.compose({
 
     simpleprefs.on(ALLOW_GEOLOCATION_PREF, this._onallowed.bind(this), this);
 
+    this.monitor();
   },
 
   // Sets a position watch, updating the object cache as it changes

--- a/lib/search-engines.js
+++ b/lib/search-engines.js
@@ -27,6 +27,19 @@ const { Geolocation } = require("geolocation");
 const DEFAULT_TAG = exports.DEFAULT_TAG  = "_default";
 const FOUND_TAG = exports.FOUND_TAG = "_found";
 
+// Some translators for services whose suggestions do not match spec.
+const translators = {
+  'http://www.yelp.com/search.xml': function (req) {
+    var response = JSON.parse(req.responseText)["body"],
+        items = [];
+
+    response.replace(/\<li\s+title="([^"]+)"/g, function (match, title) {
+      items.push(title);
+    });
+
+    return items;
+  }
+};
 
 /**
  * Search Engine
@@ -359,35 +372,22 @@ const SearchEngines = EventEmitter.compose({
       // ["term", ["suggestions", "of", "matches" ]]
       // ex: ["json",["jsonline","json","json validator","jsonp"]]
       try {
-        if (engine.id == "http://www.yelp.com/search.xml") {
-          // Yelp returns a crappy HTML answer instead of JSON
-          // We just send the whole body object to the iframe to let the DOM parse it all
-          // {"body": "<ul>\n\t\t\t
-          //            <li title=\"Elysian Coffee\">Elysian<span class=\"highlight\">&nbsp;Coffee</span></li>\n\t\t\t
-          //            <li title=\"Elysian Room\">Elysian<span class=\"highlight\">&nbsp;Room</span></li>\n\t
-          //           </ul>",
-          // "unique_request_id": "a1fdaa421112b2b5"}
-          var response = JSON.parse(req.responseText)["body"];
-          this._emit("suggestions", "yelp",{ "terms" : terms, "name" : engine.name, "id" : engine.id,
-                                             "results" : response, "type" : engine.type });
-          return;
-        } else {
-          var results = [];
-          var suggestions = JSON.parse(req.responseText)[1];
-          console.log("req.responseText", req.responseText);
-          suggestions.forEach(function(item) {
-            // Break loop if we have more results than we need
-            if (results.length >= SearchEngines.maxResults) {
-              return;
-            }
-            // If the term searched matches the response then ignore it
-            if (terms != item) {
-              results.push({ "title" : item, "url" : (engine.type == "match")? engine.baseURL + item : "" });
-            }
-          });
-          this._emit("suggestions", "add",{ "name" : engine.name, "id" : engine.id,
-                                            "results" : results, "type" : engine.type, "terms" : terms });
-        }
+        var results = [],
+            translator = translators[engine.id];
+        var suggestions =  translator ? translator(req) : JSON.parse(req.responseText)[1];
+        console.log("req.responseText", req.responseText);
+        suggestions.forEach(function(item) {
+          // Break loop if we have more results than we need
+          if (results.length >= SearchEngines.maxResults) {
+            return;
+          }
+          // If the term searched matches the response then ignore it
+          if (terms != item) {
+            results.push({ "title" : item, "url" : (engine.type == "match")? engine.baseURL + item : "" });
+          }
+        });
+        this._emit("suggestions", "add",{ "name" : engine.name, "id" : engine.id,
+                                          "results" : results, "type" : engine.type, "terms" : terms });
       } catch (error) { console.error("suggest error: " + error + "\n" + url + "\n"); }
     }.bind(this));
   },


### PR DESCRIPTION
Put a translators section at the top of search-engines.js to hold the yelp translation stuff. Just went with old-fashioned regexp stripping of title and removed the jquery title extraction, although i'm not sure if more on the esults.js can be removed. I assumed not, but still not quite familiar with it.
